### PR TITLE
fixed minor issue in compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Then you can run the project using docker-compose via
 docker-compose up -d --build
 ```
 
+Note: Try prepending the above command with sudo if running into errors 
+
 # Todo-Backend Tests
 Run the tests at: https://www.todobackend.com/specs/index.html
 First, change the test target root: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - web
   calendar-web:
     container_name: calendar-web
-    build: ./Calendar/api
+    build: ./Calendar/Api
     ports:
       - "8000:8000" # expose ports HOST:CONTAINER
     environment:
@@ -68,7 +68,7 @@ services:
       - calendar-db
   calendar-worker:
     container_name: calendar-worker
-    build: ./Calendar/app
+    build: ./Calendar/App
     environment:
       - WORKER_CONFIG=development
       - BROKER=amqp://guest:guest@todo_broker:5672
@@ -105,7 +105,7 @@ services:
   calendar-db:
     container_name: calendar-db
     hostname: calendar-db
-    build: ./Calendar/api/db
+    build: ./Calendar/Api/db
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=docker


### PR DESCRIPTION
Ubuntu 16.04 LTS
docker-compose version 1.15.0, build e12f3b9

Two issues found.

1. Running "docker-compose up -d --build" was throwing the following error. It was fixed by corrected the paths in the compose file

ERROR: build path /home/tmutton/Documents/Code/FutureStack/Calendar/api/db either does not exist, is not accessible, or is not a valid URL.

2. The same command was throwing the following error due to non elevated permissions solved by prepending sudo to said command.

me@ubuntu:~/Documents/Code/FutureStack$ docker-compose up -d --build
ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?

If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.

Added advice to suit the above in the readme file

Hope this helps

Tom